### PR TITLE
fix: eliminate login-logout loop from 429 rate limit

### DIFF
--- a/src/context/session-context.tsx
+++ b/src/context/session-context.tsx
@@ -37,16 +37,34 @@ export function SessionProvider({ children }: { children: React.ReactNode }) {
     }
     init();
 
+    const nullDebounceRef: { current: ReturnType<typeof setTimeout> | null } = { current: null };
+
     const { data: sub } = supabase.auth.onAuthStateChange((_event, s) => {
-      setSession(s);
-      const metaRole =
-        (s?.user?.user_metadata as UserMetadataWithRole | undefined)
-          ?.role_name ?? null;
-      setRoleName(typeof metaRole === "string" ? metaRole : null);
+      if (nullDebounceRef.current) {
+        clearTimeout(nullDebounceRef.current);
+        nullDebounceRef.current = null;
+      }
+
+      if (s) {
+        setSession(s);
+        const metaRole =
+          (s.user?.user_metadata as UserMetadataWithRole | undefined)
+            ?.role_name ?? null;
+        setRoleName(typeof metaRole === "string" ? metaRole : null);
+      } else {
+        nullDebounceRef.current = setTimeout(() => {
+          nullDebounceRef.current = null;
+          setSession(null);
+          setRoleName(null);
+        }, 300);
+      }
     });
 
     return () => {
       isMounted = false;
+      if (nullDebounceRef.current) {
+        clearTimeout(nullDebounceRef.current);
+      }
       sub.subscription.unsubscribe();
     };
   }, []);

--- a/src/hooks/use-auth.ts
+++ b/src/hooks/use-auth.ts
@@ -1,8 +1,9 @@
 "use client";
 
 import * as React from "react";
-import { supabase } from "@/integrations/supabase/client";
 import type { User as AuthUser } from "@supabase/supabase-js";
+import { supabase } from "@/integrations/supabase/client";
+import { useSessionContext } from "@/context/session-context";
 import type { User, Role, Permission } from "@/data/types";
 import { getPermissionsForFeature, type PermissionFeature } from "@/lib/permissions/map";
 
@@ -80,25 +81,17 @@ export function useAuth() {
     setIsLoading(false);
   };
 
+  const { session, isLoading: isSessionLoading } = useSessionContext();
+
   React.useEffect(() => {
-    supabase.auth.getSession().then(({ data: { session } }) => {
-      if (session) {
-        fetchUserProfile(session.user);
-      } else {
-        setIsLoading(false);
-      }
-    });
+    if (isSessionLoading) return;
 
-    const { data: { subscription } } = supabase.auth.onAuthStateChange((event, session) => {
-      if (event === 'SIGNED_IN' && session) {
-        fetchUserProfile(session.user);
-      } else if (event === 'SIGNED_OUT') {
-        clearAuthData();
-      }
-    });
-
-    return () => subscription.unsubscribe();
-  }, [fetchUserProfile]);
+    if (session?.user) {
+      fetchUserProfile(session.user);
+    } else {
+      clearAuthData();
+    }
+  }, [session, isSessionLoading, fetchUserProfile]);
 
   const hasPermission = (permission: Permission): boolean => {
     if (!userRole) return false;


### PR DESCRIPTION
## Summary

- **Remove duplicate session initialization** in `useAuth` — it now reads session from `SessionProvider` via `useSessionContext()` instead of independently calling `getSession()` and `onAuthStateChange`, halving token refresh requests on page load
- **Add 300ms debounce on null-session updates** in `SessionProvider` to prevent rapid sign-out thrashing when 429 rate-limit errors occur on shared IPs (Jio CGNAT)

## Root Cause

Two places (`SessionProvider` and `useAuth`) both independently called `supabase.auth.getSession()` and set up separate `onAuthStateChange` listeners, doubling token refresh requests. On shared IPs hitting Supabase's rate limit (429), this caused an infinite login→logout→login loop.

## Test plan

- [ ] On Jio ethernet PC: log in with admin credentials → should stay logged in (no logout loop)
- [ ] Check browser console — no 429 errors, no rapid state cycling
- [ ] On normal PC: log in/out → works as before
- [ ] Open two browser tabs → both stay logged in
- [ ] Let session sit for 1+ hour → token refresh works smoothly
- [ ] Sign out → redirected to login page, state cleared properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved authentication state management with more robust session handling and better synchronization between auth state and user profile data, resulting in more stable authentication behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->