### PR TITLE
fix: break login-logout loop (Phase 2 — expired token guard)

### DIFF
--- a/src/hooks/use-auth.ts
+++ b/src/hooks/use-auth.ts
@@ -2,7 +2,6 @@
 
 import * as React from "react";
 import type { User as AuthUser } from "@supabase/supabase-js";
-import { supabase } from "@/integrations/supabase/client";
 import { useSessionContext } from "@/context/session-context";
 import type { User, Role, Permission } from "@/data/types";
 import { getPermissionsForFeature, type PermissionFeature } from "@/lib/permissions/map";
@@ -62,8 +61,10 @@ export function useAuth() {
 
       lastLoadedUserIdRef.current = user.id;
     } catch (error) {
-      console.error("Failed to fetch user profile, signing out.", error);
-      await supabase.auth.signOut();
+      console.error("Failed to fetch user profile:", error);
+      // Don't call signOut() — transient errors (429-caused expired token, network)
+      // shouldn't trigger logout. If session is genuinely invalid, Supabase's
+      // auto-refresh will fire SIGNED_OUT via onAuthStateChange automatically.
     } finally {
       if (fetchInFlightUserIdRef.current === user.id) {
         fetchInFlightUserIdRef.current = null;
@@ -87,6 +88,12 @@ export function useAuth() {
     if (isSessionLoading) return;
 
     if (session?.user) {
+      // Skip profile fetch if access token is expired (e.g., 429 returned stale session).
+      // Supabase auto-refresh will deliver a fresh session via onAuthStateChange.
+      const now = Math.floor(Date.now() / 1000);
+      if (session.expires_at && session.expires_at < now) {
+        return;
+      }
       fetchUserProfile(session.user);
     } else {
       clearAuthData();

--- a/src/lib/auth/client-session.ts
+++ b/src/lib/auth/client-session.ts
@@ -8,12 +8,10 @@ export async function getValidSession() {
     return data.session;
   }
 
-  const { data: refreshed, error: refreshError } =
-    await supabase.auth.refreshSession();
-  if (refreshError || !refreshed.session) {
-    return null;
-  }
-  return refreshed.session;
+  // getSession() already handles token refresh internally.
+  // Explicit refreshSession() fallback doubled refresh requests,
+  // accelerating rate limit exhaustion on shared IPs (CGNAT).
+  return null;
 }
 
 export type AuthorizedFetchOptions = RequestInit & { retryOnUnauthorized?: boolean };


### PR DESCRIPTION
## Summary

Phase 2 fix for the login-logout loop that persists after PR #145. The 429 rate limit on Jio ethernet (CGNAT shared IP) causes Supabase to return stale sessions with expired access tokens, triggering a cascade:

**Root cause chain**: expired token → profile fetch fails (406 PGRST116) → `signOut()` in catch block → logout → re-login → 429 again → loop

**Changes:**
- **Remove `signOut()` from `fetchUserProfile` catch block** — transient errors no longer trigger logout. Supabase auto-refresh handles genuinely invalid sessions via `onAuthStateChange`
- **Add `session.expires_at` guard** before profile fetch — skip doomed requests when 429 returns a stale session with an expired access token
- **Remove redundant `refreshSession()` fallback** in `getValidSession()` — `getSession()` already refreshes internally; the fallback doubled rate limit pressure on shared IPs

## Test plan

- [ ] On Jio ethernet PC: log in → stays logged in (no logout loop, may see loading spinner briefly if 429 hits)
- [ ] Browser console: no `Failed to fetch user profile, signing out` message, no rapid `[AppData]` cycling
- [ ] On normal PC: log in/out works as before (no regression)
- [ ] Two browser tabs → both stay logged in
- [ ] Session idle 1+ hour → token refresh works smoothly
- [ ] Sign out via sidebar → redirected to login, state cleared

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session management to automatically handle expired sessions without interrupting user experience.
  * Enhanced authentication error handling to prevent unnecessary logouts during temporary failures.
  * Optimized session token refresh logic to eliminate redundant requests and improve performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->