### PR TITLE
fix: retry 429 errors and ignore transient sign-outs to prevent login loop

### DIFF
--- a/src/components/auth/admin/login-form.tsx
+++ b/src/components/auth/admin/login-form.tsx
@@ -14,6 +14,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { ShieldCheck, CalendarCheck, LineChart } from "lucide-react";
 import { toast } from "sonner";
 import { supabase } from "@/integrations/supabase/client";
+import { signOutUser } from "@/context/session-context";
 import { getUserProfile } from "@/lib/api";
 import { ADMIN_ROLES } from "@/constants/roles";
 
@@ -91,7 +92,7 @@ export function AdminLoginForm() {
       const isAdminRole = ADMIN_ROLES.some((adminRole) => adminRole === roleName);
 
       if (!roleName || !isAdminRole) {
-        await supabase.auth.signOut();
+        await signOutUser();
         toast.error("Admins only", { description: "Use the guest portal at /login." });
         setIsLoading(false);
         return;

--- a/src/components/auth/login-form.tsx
+++ b/src/components/auth/login-form.tsx
@@ -26,6 +26,7 @@ import {
 } from "@/components/ui/card";
 import { toast } from "sonner";
 import { supabase } from "@/integrations/supabase/client";
+import { signOutUser } from "@/context/session-context";
 import { getUserProfile } from "@/lib/api";
 
 const formSchema = z.object({
@@ -117,7 +118,7 @@ export function LoginForm({ redirectTo = "/dashboard", forgotPasswordHref = "/fo
       }
 
       if (allowedRoleNames && roleName && !allowedRoleNames.includes(roleName)) {
-        await supabase.auth.signOut();
+        await signOutUser();
         toast.error("You cannot sign in here.", {
           description: "Use the appropriate portal for your role.",
         });

--- a/src/components/auth/user/login-form.tsx
+++ b/src/components/auth/user/login-form.tsx
@@ -12,6 +12,7 @@ import { Input } from "@/components/ui/input";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { toast } from "sonner";
 import { supabase } from "@/integrations/supabase/client";
+import { signOutUser } from "@/context/session-context";
 import { getUserProfile } from "@/lib/api";
 
 const formSchema = z.object({
@@ -86,7 +87,7 @@ export function UserLoginForm() {
       }
 
       if (roleName && roleName !== "Guest") {
-        await supabase.auth.signOut();
+        await signOutUser();
         toast.error("Guests only", { description: "Use the admin portal at /admin/login." });
         setIsLoading(false);
         return;

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -21,7 +21,7 @@ import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet";
 import { useDataContext } from "@/context/data-context";
 import { useAuthContext } from "@/context/auth-context";
 import { ThemeToggle } from "../theme-toggle";
-import { supabase } from "@/integrations/supabase/client";
+import { signOutUser } from "@/context/session-context";
 import type { Permission } from "@/data/types";
 import { getPermissionsForFeature, type PermissionFeature } from "@/lib/permissions/map";
 import Image from "next/image";
@@ -61,7 +61,7 @@ export function Header() {
   const userRole = roles.find(r => r.id === currentUser?.roleId);
 
   const handleLogout = async () => {
-    await supabase.auth.signOut();
+    await signOutUser();
     router.push("/admin/login");
   };
 

--- a/src/context/session-context.tsx
+++ b/src/context/session-context.tsx
@@ -4,6 +4,13 @@ import * as React from "react";
 import type { Session } from "@supabase/supabase-js";
 import { supabase } from "@/integrations/supabase/client";
 
+let pendingIntentionalSignOut = false;
+
+export async function signOutUser(): Promise<void> {
+  pendingIntentionalSignOut = true;
+  await supabase.auth.signOut();
+}
+
 interface UserMetadataWithRole {
   role_name?: string;
 }
@@ -37,14 +44,7 @@ export function SessionProvider({ children }: { children: React.ReactNode }) {
     }
     init();
 
-    const nullDebounceRef: { current: ReturnType<typeof setTimeout> | null } = { current: null };
-
     const { data: sub } = supabase.auth.onAuthStateChange((_event, s) => {
-      if (nullDebounceRef.current) {
-        clearTimeout(nullDebounceRef.current);
-        nullDebounceRef.current = null;
-      }
-
       if (s) {
         setSession(s);
         const metaRole =
@@ -52,19 +52,17 @@ export function SessionProvider({ children }: { children: React.ReactNode }) {
             ?.role_name ?? null;
         setRoleName(typeof metaRole === "string" ? metaRole : null);
       } else {
-        nullDebounceRef.current = setTimeout(() => {
-          nullDebounceRef.current = null;
+        if (pendingIntentionalSignOut) {
+          pendingIntentionalSignOut = false;
           setSession(null);
           setRoleName(null);
-        }, 300);
+        }
+        // If not intentional (likely 429 on token refresh), keep existing session.
       }
     });
 
     return () => {
       isMounted = false;
-      if (nullDebounceRef.current) {
-        clearTimeout(nullDebounceRef.current);
-      }
       sub.subscription.unsubscribe();
     };
   }, []);

--- a/src/integrations/supabase/client.ts
+++ b/src/integrations/supabase/client.ts
@@ -7,7 +7,7 @@ type BrowserSupabaseClient = SupabaseClient;
 let cachedClient: BrowserSupabaseClient | undefined;
 
 const FETCH_TIMEOUT_MS = 15_000;
-const MAX_RETRIES = 2;
+const MAX_RETRIES = 3;
 
 async function fetchWithRetry(
   input: RequestInfo | URL,
@@ -25,6 +25,15 @@ async function fetchWithRetry(
         signal: controller.signal,
       });
       clearTimeout(timeoutId);
+
+      if (response.status === 429 && attempt < MAX_RETRIES) {
+        const retryAfter = response.headers.get("Retry-After");
+        const delay = retryAfter
+          ? parseInt(retryAfter, 10) * 1000
+          : Math.min(2000 * 2 ** attempt, 15_000);
+        await new Promise((r) => setTimeout(r, delay));
+        continue;
+      }
 
       if (response.status >= 500 && attempt < MAX_RETRIES) {
         await new Promise((r) => setTimeout(r, 1000 * 2 ** attempt));


### PR DESCRIPTION
## Summary

- **429 retry in `fetchWithRetry`**: All Supabase requests (including internal token refresh) now retry 429 errors with exponential backoff (2s, 4s, 8s), respecting `Retry-After` header. `MAX_RETRIES` bumped from 2 → 3.
- **Intentional sign-out tracking**: `onAuthStateChange` only clears session when `signOutUser()` was called (user clicked logout / role rejection). Transient `SIGNED_OUT` events from 429 failures are ignored — the user stays logged in.
- **All 4 sign-out callers** (header, login-form, user/login-form, admin/login-form) now use `signOutUser()` instead of `supabase.auth.signOut()` directly.

## Context

Phase 2 (PR #146) fixed the profile-fetch sign-out but the login loop persisted on Jio ethernet PC. Root cause: Supabase SDK itself fires `SIGNED_OUT` when internal token refresh gets 429. Our code can't prevent the SDK from doing this, but we can (1) retry 429s so the SDK never sees them, and (2) ignore the resulting sign-out if the user didn't intend it.

## Test plan

- [ ] On Jio ethernet PC: log in → stays logged in (no logout loop)
- [ ] Normal PC: login/logout works as before
- [ ] Intentional logout (header button) → redirects to login immediately
- [ ] Wrong role login (guest on admin portal) → error toast + session clears
- [ ] Two browser tabs → both stay logged in
- [ ] Session idle 1+ hour → token refresh works (with retry if needed)
- [ ] Network tab: 429 responses show retries with increasing delays

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session logout handling with centralized sign-out mechanism for more reliable user sign-offs across the application.
  * Enhanced API request resilience by adding rate-limit detection and increasing retry attempts for better reliability during high-traffic periods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->