### PR TITLE
fix: deduplicate token refresh to stop 429 login loop

### DIFF
--- a/src/context/session-context.tsx
+++ b/src/context/session-context.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react";
 import type { Session } from "@supabase/supabase-js";
-import { supabase } from "@/integrations/supabase/client";
+import { supabase, lastRefreshRateLimited } from "@/integrations/supabase/client";
 
 let pendingIntentionalSignOut = false;
 
@@ -30,17 +30,33 @@ export function SessionProvider({ children }: { children: React.ReactNode }) {
   const [isLoading, setIsLoading] = React.useState(true);
   const [roleName, setRoleName] = React.useState<string | null>(null);
 
+  const initRetryCount = React.useRef(0);
+  const MAX_INIT_RETRIES = 3;
+
   React.useEffect(() => {
     let isMounted = true;
     async function init() {
       const { data } = await supabase.auth.getSession();
       if (!isMounted) return;
-      setSession(data.session);
-      const metaRole =
-        (data.session?.user?.user_metadata as UserMetadataWithRole | undefined)
-          ?.role_name ?? null;
-      setRoleName(typeof metaRole === "string" ? metaRole : null);
-      setIsLoading(false);
+
+      if (data.session) {
+        initRetryCount.current = 0;
+        setSession(data.session);
+        const metaRole =
+          (data.session?.user?.user_metadata as UserMetadataWithRole | undefined)
+            ?.role_name ?? null;
+        setRoleName(typeof metaRole === "string" ? metaRole : null);
+        setIsLoading(false);
+      } else if (lastRefreshRateLimited && initRetryCount.current < MAX_INIT_RETRIES) {
+        // Token refresh hit 429 — don't set null, keep loading, retry after delay
+        initRetryCount.current += 1;
+        setTimeout(() => { if (isMounted) init(); }, 30_000);
+      } else {
+        // Genuinely not logged in (or retries exhausted)
+        setSession(null);
+        setRoleName(null);
+        setIsLoading(false);
+      }
     }
     init();
 

--- a/src/integrations/supabase/client.ts
+++ b/src/integrations/supabase/client.ts
@@ -9,7 +9,61 @@ let cachedClient: BrowserSupabaseClient | undefined;
 const FETCH_TIMEOUT_MS = 15_000;
 const MAX_RETRIES = 3;
 
+// --- Token refresh dedup + cooldown ---
+let inflightRefresh: Promise<Response> | null = null;
+let refreshCooldownUntil = 0;
+
+/** Exported so session-context can check if a 429 caused the null session */
+export let lastRefreshRateLimited = false;
+
+function isTokenRefresh(input: RequestInfo | URL, init?: RequestInit): boolean {
+  const url =
+    typeof input === "string"
+      ? input
+      : input instanceof URL
+        ? input.href
+        : input.url;
+  return url.includes("/auth/v1/token") && init?.method?.toUpperCase() === "POST";
+}
+
 async function fetchWithRetry(
+  input: RequestInfo | URL,
+  init?: RequestInit
+): Promise<Response> {
+  // --- Dedup: only one token refresh in-flight at a time ---
+  if (isTokenRefresh(input, init)) {
+    // Cooldown: return synthetic 429 without hitting network
+    if (Date.now() < refreshCooldownUntil) {
+      return new Response(JSON.stringify({ message: "rate limited (local cooldown)" }), {
+        status: 429,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    if (inflightRefresh) {
+      // Another refresh is already in-flight; share its result
+      return (await inflightRefresh).clone();
+    }
+
+    inflightRefresh = doFetch(input, init);
+    try {
+      const res = await inflightRefresh;
+      if (res.status === 429) {
+        lastRefreshRateLimited = true;
+        refreshCooldownUntil = Date.now() + 30_000;
+      } else {
+        lastRefreshRateLimited = false;
+      }
+      return res.clone();
+    } finally {
+      inflightRefresh = null;
+    }
+  }
+
+  return doFetch(input, init);
+}
+
+async function doFetch(
   input: RequestInfo | URL,
   init?: RequestInit
 ): Promise<Response> {


### PR DESCRIPTION
## Summary
- **Deduplicate token refresh**: concurrent SDK callers (init, auto-refresh, tab-focus, authorizedFetch) now share a single in-flight request via promise caching, cutting ~16 requests down to ~4
- **30s cooldown**: after a final 429 failure, all refresh requests return a synthetic 429 locally for 30 seconds — no network hit
- **Protect init()**: when `getSession()` returns null due to rate-limiting, keeps `isLoading=true` and retries after 30s (up to 3 times) instead of falsely redirecting to login

## Files changed
- `src/integrations/supabase/client.ts` — dedup wrapper, cooldown, `lastRefreshRateLimited` export
- `src/context/session-context.tsx` — rate-limit-aware `init()` with retry

## Test plan
- [ ] On Jio ethernet PC: log in → should stay logged in (may see loading spinner up to 90s if 429 persists, but NO redirect to login)
- [ ] Browser console: at most 4 network requests per refresh cycle, NOT 16+
- [ ] On normal PC: login/logout works as before (no regression)
- [ ] Intentional logout: click logout → redirects to login immediately
- [ ] Wrong role login: error toast + session clears
- [ ] Two browser tabs: both stay logged in
- [ ] Session idle 1+ hour: token refresh works

🤖 Generated with [Claude Code](https://claude.com/claude-code)